### PR TITLE
Use the version specified in the .env file when cloning WriteFreely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.22/community" >> /e
 
 WORKDIR /tmp
 
-RUN git clone https://github.com/writefreely/writefreely.git
+RUN git clone https://github.com/writefreely/writefreely.git && \
+    cd writefreely && \
+    git checkout "v${VERSION}"
 
 WORKDIR /tmp/writefreely
 


### PR DESCRIPTION
Previously, the Docker build always cloned the latest version of the WriteFreely repository. With this change, the build now clones the exact version specified by the VERSION variable in the .env file, ensuring that the source code matches the intended release.